### PR TITLE
add repos containing -web- and -prework strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 ## Getting Started
 Generate a [GitHub token](https://github.com/settings/tokens/new) with the ```public_repo``` and ```delete_repo``` permissions.
 
-**All repositories containing the strings ```online-web``` or ```bootcamp-prep``` will be removed after you give confirmation in the CLI.**
+**All repositories containing the strings ```online-web```,  ```bootcamp-prep```, ```-web-```, or ```-prework``` will be removed after you give confirmation in the CLI.**
 
 ## Installation
-1. Install the package: ```npm install -g delete-flatiron-repos```
+1. Install the package: ```npm install -g delete-flatiron-repos``` and ensure you're running Node v12+
 2. Run ```delete-flatiron-repos``` from the command line.

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const schema = {
 let owner;
 let githubToken;
 
-const deleteIfIncluded = ['online-web', 'bootcamp-prep'];
+const deleteIfIncluded = ['online-web', 'bootcamp-prep', '-web-', '-prework'];
 
 async function deleteFlatironRepos() {
 	const octokit = new Octokit({


### PR DESCRIPTION
@kodyclemens, this is an awesome script! I was enrolled in the on-site curriculum and our repos all contained `-web-`. I also added in any prework repos that contain `-prework`. I realize I could have edited the `online-web` down to just `-web`, but I figured it's more evident what the code is doing to add a new string.